### PR TITLE
切换metrics-server-amd64为腾讯云镜像

### DIFF
--- a/tke-skill/install-metrics-server-on-tke.md
+++ b/tke-skill/install-metrics-server-on-tke.md
@@ -8,7 +8,7 @@ git clone https://github.com/kubernetes-incubator/metrics-server.git
 ``` yaml
       containers:
       - name: metrics-server
-        image: k8s.gcr.io/metrics-server-amd64:v0.3.1
+        image: ccr.ccs.tencentyun.com/mirrors/metrics-server-amd64:v0.3.1
         args: ["--kubelet-insecure-tls"] # 这里是新增的一行
         imagePullPolicy: Always
 ```


### PR DESCRIPTION
k8s.gcr.io/metrics-server-amd64:v0.3.1
换为ccr.ccs.tencentyun.com/mirrors/metrics-server-amd64:v0.3.1
